### PR TITLE
Windows links

### DIFF
--- a/autostart_windows.go
+++ b/autostart_windows.go
@@ -3,7 +3,6 @@ package autostart
 import (
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 var startupDir string
@@ -13,7 +12,7 @@ func init() {
 }
 
 func (a *App) path() string {
-	return filepath.Join(startupDir, a.Name + ".bat")
+	return filepath.Join(startupDir, a.Name+".exe")
 }
 
 func (a *App) IsEnabled() bool {
@@ -22,18 +21,9 @@ func (a *App) IsEnabled() bool {
 }
 
 func (a *App) Enable() error {
-	s := "start " + strings.Join(a.Exec, " ") + "\r\n"
-
-	f, err := os.Create(a.path())
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	_, err = f.Write([]byte(s))
-	return err
+	return os.Link(a.Exec[0], filepath.Join(startupDir, a.Name+".exe"))
 }
 
 func (a *App) Disable() error {
-	return os.Remove(a.path())
+	return os.Remove(filepath.Join(startupDir, a.Name+".exe"))
 }

--- a/autostart_windows.go
+++ b/autostart_windows.go
@@ -21,9 +21,9 @@ func (a *App) IsEnabled() bool {
 }
 
 func (a *App) Enable() error {
-	return os.Link(a.Exec[0], filepath.Join(startupDir, a.Name+".exe"))
+	return os.Link(a.Exec[0], a.path())
 }
 
 func (a *App) Disable() error {
-	return os.Remove(filepath.Join(startupDir, a.Name+".exe"))
+	return os.Remove(a.path())
 }

--- a/autostart_xdg.go
+++ b/autostart_xdg.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func (a *App) path() string {
-	return filepath.Join(autostartDir, a.Name + ".desktop")
+	return filepath.Join(autostartDir, a.Name+".desktop")
 }
 
 // Check if the app is enabled on startup.


### PR DESCRIPTION
Previous system using .bat files did not work because it couldn't handle spaces (https://github.com/ProtonMail/go-autostart/issues/3) and we want to use the folder Program Files for installation. 
Instead, we create a link to the bridge executable and add it to the Startup folder if the user enables this option.