### PR TITLE
Is enabled only when stat is ok

### DIFF
--- a/autostart_darwin.go
+++ b/autostart_darwin.go
@@ -36,7 +36,7 @@ func (a *App) path() string {
 // IsEnabled Check is app enabled startup.
 func (a *App) IsEnabled() bool {
 	_, err := os.Stat(a.path())
-	return !os.IsNotExist(err)
+	return err == nil
 }
 
 // Enable this app on startup.

--- a/autostart_windows.go
+++ b/autostart_windows.go
@@ -29,8 +29,7 @@ func (a *App) path() string {
 
 func (a *App) IsEnabled() bool {
 	_, err := os.Stat(a.path())
-
-	return !os.IsNotExist(err)
+	return err == nil
 }
 
 func (a *App) Enable() error {

--- a/autostart_xdg.go
+++ b/autostart_xdg.go
@@ -34,7 +34,7 @@ func (a *App) path() string {
 // Check if the app is enabled on startup.
 func (a *App) IsEnabled() bool {
 	_, err := os.Stat(a.path())
-	return !os.IsNotExist(err)
+	return err == nil
 }
 
 type app struct {


### PR DESCRIPTION
Right now when user has wrong permissions to launch folder it returns that the autostart is enabled. It is better to return not enabled when we can not decide.