### PR TITLE
xdg: Icon entry in .desktop needs to be in a new line

### DIFF
--- a/autostart_xdg.go
+++ b/autostart_xdg.go
@@ -12,7 +12,8 @@ const desktopTemplate = `[Desktop Entry]
 Type=Application
 Name={{.DisplayName}}
 Exec={{.Exec}}
-{{- if .Icon}}Icon={{.Icon}}{{end}}
+{{- if .Icon}}
+Icon={{.Icon}}{{end}}
 X-GNOME-Autostart-enabled=true
 `
 


### PR DESCRIPTION
Put the Icon entry on the .desktop entry in a different line than the
Exec entry.