### PR TITLE
fix(BRIDGE-431): use a copy of args in quote function instead of modifying the original one in autostart_linux

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -8,9 +8,11 @@ import (
 )
 
 func quote(args []string) string {
+	copyArgs := make([]string, len(args))
+
 	for i, v := range args {
-		args[i] = strconv.Quote(v)
+		copyArgs[i] = strconv.Quote(v)
 	}
 
-	return strings.Join(args, " ")
+	return strings.Join(copyArgs, " ")
 }


### PR DESCRIPTION
`quote.go`, modified the original passed `args` array which when enabling or disabling the autostart mechanism on bridge added extra quotes which in turn lead to a bug in the .desktop entry on linux systems. 